### PR TITLE
Fix constraints for `shouldBeApproxPrec` and add lifted approximate equality expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,32 @@ Create approximately equal expectation with margin.
 ```haskell
 shouldBeApprox' = shouldBeApproxPrec 1e-9
 ```
+
+#### Lifted Approximate Equality
+
+##### `shouldBeApprox1`/`shouldBeApproxPrec1`
+
+```haskell
+shouldBeApprox1 :: (Fractional a, Ord a, Show a, Show (t a), Eq1 t) => t a -> t a -> Expectation
+shouldBeApproxPrec1 :: (Num a, Ord a, Show a, Show (t a), Eq1 t) => a -> t a -> t a -> Expectation
+```
+
+Similar to `shouldBeApprox`/`shouldBeApproxPrec` with equality lifted via `Eq1`.
+
+##### `shouldBeApprox2`/`shouldBeApproxPrec2`
+
+```haskell
+shouldBeApprox2 :: (Fractional a, Ord a, Fractional b, Ord b, Show a, Show b, Show (t a b), Eq2 t) => t a b -> t a b -> Expectation
+shouldBeApproxPrec2 :: (Num a, Ord a, Num b, Ord b, Show a, Show b, Show (t a b), Eq2 t) => a -> b -> t a b -> t a b -> Expectation
+```
+
+Similar to `shouldBeApprox`/`shouldBeApproxPrec` with equality lifted via `Eq2`. Note that two margins of error are required.
+
+##### `shouldBeApprox2'`/`shouldBeApproxPrec2'`
+
+```haskell
+shouldBeApprox2' :: (Fractional a, Show a, Show (t a a), Ord a, Eq2 t) => t a a -> t a a -> Expectation
+shouldBeApproxPrec2' :: (Show a, Show (t a a), Num a, Ord a, Eq2 t) => a -> t a a -> t a a -> Expectation
+```
+
+Similar to `shouldBeApprox2`/`shouldBeApproxPrec2` where both margins of error are of identical type and value.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sqrt 2.0 `shouldBeApprox` (1.4142135 :: Double)
 #### `shouldBeApproxPrec`
 
 ```haskell
-shouldBeApproxPrec :: (Fractional a, Ord a, Show a) => a -> a -> a -> Expectation
+shouldBeApproxPrec :: (Num a, Ord a, Show a) => a -> a -> a -> Expectation
 ```
 
 Create approximately equal expectation with margin.

--- a/src/Test/Hspec/Codewars.hs
+++ b/src/Test/Hspec/Codewars.hs
@@ -120,13 +120,12 @@ infix 1 `shouldBeApprox`
 shouldBeApprox :: (Fractional a, Ord a, Show a) => a -> a -> Expectation
 shouldBeApprox = shouldBeApproxPrec 1e-6
 
--- | Wrapper for values to be compared for approximate equality. The margin of
--- error is bundled with the expected value as @'Expected' margin value@. The
+-- | Wrapper for values to be compared for approximate equality. The
 -- 'Show' instance is altered so that failure messages also show the margin of
 -- error.
 data Approx a
   = Actual a
-  | Expected a a
+  | Expected a a -- ^ @Expected margin value@
 
 -- | @isApprox margin actual expected@ determines if @actual@ is approximately
 -- equal to @expected@ within the given @margin@.
@@ -196,3 +195,10 @@ shouldBeApproxPrec2 margin1 margin2 actual expected =
 
 shouldBeApprox2 :: (Fractional a, Ord a, Fractional b, Ord b, Show a, Show b, Show (t a b), Eq2 t) => t a b -> t a b -> Expectation
 shouldBeApprox2 = shouldBeApproxPrec2 1e-6 1e-6
+
+shouldBeApproxPrec2' :: (Show a, Show (t a a), Num a, Ord a, Eq2 t) => a -> t a a -> t a a -> Expectation
+shouldBeApproxPrec2' margin actual expected =
+  Actual2 actual `shouldBe` Expected2 margin margin expected
+
+shouldBeApprox2' :: (Fractional a, Show a, Show (t a a), Ord a, Eq2 t) => t a a -> t a a -> Expectation
+shouldBeApprox2' = shouldBeApproxPrec2' 1e-6

--- a/src/Test/Hspec/Codewars.hs
+++ b/src/Test/Hspec/Codewars.hs
@@ -8,8 +8,8 @@ module Test.Hspec.Codewars (
   Hidden(..),
   solutionShouldHide,
   solutionShouldHideAll,
-  shouldBeApproxPrec, shouldBeApproxPrec1, shouldBeApproxPrec2,
-  shouldBeApprox, shouldBeApprox1, shouldBeApprox2,
+  shouldBeApproxPrec, shouldBeApproxPrec1, shouldBeApproxPrec2, shouldBeApproxPrec2',
+  shouldBeApprox, shouldBeApprox1, shouldBeApprox2, shouldBeApprox2',
   isApprox,
   Approx(..), Approx1(..), Approx2(..),
 ) where

--- a/src/Test/Hspec/Codewars.hs
+++ b/src/Test/Hspec/Codewars.hs
@@ -147,8 +147,8 @@ instance Show a => Show (Approx a) where
   showsPrec p (Expected m e) =
     showParen (p > 10) $ shows e . showString " within margin of " . shows m
 
--- | Wrapper for values to be compared for approximate equality, lifted via the
--- 'Eq1' instance of the unary type constructor.
+-- | Wrapper for values to be compared for approximate equality within a given
+-- margin of error, lifted via the 'Eq1' instance of the unary type constructor.
 data Approx1 t a
   = Actual1 (t a)
   | Expected1 a (t a)
@@ -170,6 +170,9 @@ shouldBeApproxPrec1 :: (Num a, Ord a, Show a, Show (t a), Eq1 t) => a -> t a -> 
 shouldBeApproxPrec1 margin actual expected =
   Actual1 actual `shouldBe` Expected1 margin expected
 
+-- | Wrapper for values to be compared for approximate equality within two given
+-- margins of error, lifted via the 'Eq2' instance of the binary type
+-- constructor.
 data Approx2 t a b
   = Actual2 (t a b)
   | Expected2 a b (t a b)

--- a/src/Test/Hspec/Codewars.hs
+++ b/src/Test/Hspec/Codewars.hs
@@ -106,7 +106,7 @@ solutionShouldHideAll = hidden
 -- | Create approximately equal expectation with margin.
 --
 -- > shouldBeApprox' = shouldBeApproxPrec 1e-9
-shouldBeApproxPrec :: (Fractional a, Ord a, Show a) => a -> a -> a -> Expectation
+shouldBeApproxPrec :: (Num a, Ord a, Show a) => a -> a -> a -> Expectation
 shouldBeApproxPrec margin actual expected =
   Actual actual `shouldBe` Expected margin expected
 

--- a/src/Test/Hspec/Codewars.hs
+++ b/src/Test/Hspec/Codewars.hs
@@ -8,10 +8,13 @@ module Test.Hspec.Codewars (
   Hidden(..),
   solutionShouldHide,
   solutionShouldHideAll,
-  shouldBeApproxPrec,
-  shouldBeApprox
+  shouldBeApproxPrec, shouldBeApproxPrec1, shouldBeApproxPrec2,
+  shouldBeApprox, shouldBeApprox1, shouldBeApprox2,
+  isApprox,
+  Approx(..), Approx1(..), Approx2(..),
 ) where
 
+import Data.Functor.Classes (Eq1 (..), Eq2 (liftEq2))
 import Data.List (intercalate)
 import Text.Printf
 import Test.Hspec
@@ -87,7 +90,7 @@ hidden hiddens = do
   let failures = [(desc, hide) | desc <- imports, hide <- hiddens, exposed desc hide]
   let message = "Import declarations must hide " ++ show hiddens
   assertBool message $ null failures
-  
+
 -- | Check that solution hides a module or a symbol from a module.
 --
 -- > solutionShouldHide $ FromModule "Prelude" "head"
@@ -105,14 +108,7 @@ solutionShouldHideAll = hidden
 -- > shouldBeApprox' = shouldBeApproxPrec 1e-9
 shouldBeApproxPrec :: (Fractional a, Ord a, Show a) => a -> a -> a -> Expectation
 shouldBeApproxPrec margin actual expected =
-  if abs (actual - expected) < abs margin * max 1 (abs expected)
-    then return ()
-    else expectationFailure message
-  where
-    message = concat [
-      "Test Failed\nexpected: ", show expected,
-      " within margin of ", show margin,
-      "\n but got: ", show actual]
+  Actual actual `shouldBe` Expected margin expected
 
 infix 1 `shouldBeApprox`
 
@@ -123,3 +119,77 @@ infix 1 `shouldBeApprox`
 -- > sqrt 2.0 `shouldBeApprox` (1.4142135 :: Double)
 shouldBeApprox :: (Fractional a, Ord a, Show a) => a -> a -> Expectation
 shouldBeApprox = shouldBeApproxPrec 1e-6
+
+-- | Wrapper for values to be compared for approximate equality. The margin of
+-- error is bundled with the expected value as @'Expected' margin value@. The
+-- 'Show' instance is altered so that failure messages also show the margin of
+-- error.
+data Approx a
+  = Actual a
+  | Expected a a
+
+-- | @isApprox margin actual expected@ determines if @actual@ is approximately
+-- equal to @expected@ within the given @margin@.
+isApprox :: (Num a, Ord a) => a -> a -> a -> Bool
+isApprox margin actual expected =
+  abs (actual - expected) <= abs margin * max 1 (abs expected)
+
+instance (Num a, Ord a) => Eq (Approx a) where
+  Actual a == Expected m e = isApprox m a e
+  Expected m e == Actual a = isApprox m a e
+  _ == _ = eqApproxError
+
+eqApproxError :: a
+eqApproxError = error "equality only supported between actual/expected values"
+
+instance Show a => Show (Approx a) where
+  showsPrec p (Actual a)     = showsPrec p a
+  showsPrec p (Expected m e) =
+    showParen (p > 10) $ shows e . showString " within margin of " . shows m
+
+-- | Wrapper for values to be compared for approximate equality, lifted via the
+-- 'Eq1' instance of the unary type constructor.
+data Approx1 t a
+  = Actual1 (t a)
+  | Expected1 a (t a)
+
+instance (Num a, Ord a, Eq1 t) => Eq (Approx1 t a) where
+  Actual1 a == Expected1 m e = liftEq (isApprox m) a e
+  Expected1 m e == Actual1 a = liftEq (isApprox m) a e
+  _ == _ = eqApproxError
+
+instance (Show a, Show (t a)) => Show (Approx1 t a) where
+  showsPrec p (Actual1 a) = showsPrec p a
+  showsPrec p (Expected1 m e) =
+    showParen (p > 10) $ shows e . showString " within margin of " . shows m
+
+shouldBeApprox1 :: (Fractional a, Ord a, Show a, Show (t a), Eq1 t) => t a -> t a -> Expectation
+shouldBeApprox1 = shouldBeApproxPrec1 1e-6
+
+shouldBeApproxPrec1 :: (Num a, Ord a, Show a, Show (t a), Eq1 t) => a -> t a -> t a -> Expectation
+shouldBeApproxPrec1 margin actual expected =
+  Actual1 actual `shouldBe` Expected1 margin expected
+
+data Approx2 t a b
+  = Actual2 (t a b)
+  | Expected2 a b (t a b)
+
+instance (Num a, Ord a, Num b, Ord b, Eq2 t) => Eq (Approx2 t a b) where
+  Actual2 a == Expected2 m1 m2 e = liftEq2 (isApprox m1) (isApprox m2) a e
+  Expected2 m1 m2 e == Actual2 a = liftEq2 (isApprox m1) (isApprox m2) a e
+  _ == _ = eqApproxError
+
+instance (Show a, Show b, Show (t a b)) => Show (Approx2 t a b) where
+  showsPrec p (Actual2 a) = showsPrec p a
+  showsPrec p (Expected2 m1 m2 e) =
+    showParen (p > 10) $
+      shows e .
+      showString " within margins of " . shows m1 .
+      showString " and " . shows m2
+
+shouldBeApproxPrec2 :: (Num a, Ord a, Num b, Ord b, Show a, Show b, Show (t a b), Eq2 t) => a -> b -> t a b -> t a b -> Expectation
+shouldBeApproxPrec2 margin1 margin2 actual expected =
+  Actual2 actual `shouldBe` Expected2 margin1 margin2 expected
+
+shouldBeApprox2 :: (Fractional a, Ord a, Fractional b, Ord b, Show a, Show b, Show (t a b), Eq2 t) => t a b -> t a b -> Expectation
+shouldBeApprox2 = shouldBeApproxPrec2 1e-6 1e-6


### PR DESCRIPTION
This branch adds functions that lift approximate equality to unary/binary type constructors that are instances of `Eq1`/`Eq2`, making it easier to assert approximate equality for higher order types like `[Double]` or `(Float, Double)`.

Branch also updates the constraint for `shouldBeApproxPrec` to use `Num` instead of `Fractional`.